### PR TITLE
license changes from develop to main  (#42)

### DIFF
--- a/KeyFlowSolution.sln
+++ b/KeyFlowSolution.sln
@@ -5,6 +5,13 @@ VisualStudioVersion = 17.6.33815.320
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "KeyFlow", "KeyFlow\KeyFlow.vcxproj", "{4B2F9E24-8657-49A8-ADCA-F94E0194B4B2}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{499DD62A-BA04-44A1-BF35-BBA46C3C9867}"
+	ProjectSection(SolutionItems) = preProject
+		.gitignore = .gitignore
+		LICENSE.md = LICENSE.md
+		README.md = README.md
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x64 = Debug|x64

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,21 @@
+# MIT License
+
+Copyright (c) 2023 Hetul Bhatt
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE

--- a/README.md
+++ b/README.md
@@ -13,12 +13,14 @@ Features
 
 Getting Started
 To start using KeyFlow, follow these simple steps:
-1. Clone the KeyFlow repository to your local machine running Windows.
-2. Build the project by using the command `g++ -std=c++17 main.cpp`.
-3. Run the executable file to launch the KeyFlow application. Make sure that the config files (`../config/codes.config` and `../config/shortcuts.config`) are located in their respective directories.
-4. If the config files are not found in their default locations, you have the option to provide custom paths via command line arguments. For example, use `main.exe <path-to-shortcuts.config> <path-to-codes.config>` to specify the paths.
-5. Personalize your cheat codes, key combinations, hotwords, and associated actions using the guide provided below.
-   
+1. Clone the KeyFlow repository to your local machine.
+2. Build the project using Visual Studio 2022 IDE and the MSVC compiler:
+  - Open the KeyFlow solution (.sln) file in Visual Studio 2022.
+  - Build the solution using the IDE's build commands.
+3. Run the executable file to launch the KeyFlow application. Ensure that the configuration files (../config/codes.config and ../config/shortcuts.config) are located in their respective directories.
+4. In case the configuration files are not found in their default locations, you can provide custom paths through command line arguments. Right click on KeyFlow project in the solution explorer and click "Properties". Specify command line arguments in "Configuration Properties > Debugging > Command Arguments".
+5. Customize your cheat codes, key combinations, hotwords, and associated actions using the provided guide below.   
+
    For `shortcuts.config`:
    - The left-hand side of the operator represents the desired key combination. To understand more about nomanclature of keys, refer to the table at the end.
    - Depending on the operator used, the right-hand side can either be a string to be printed in the active window or the path to an executable program.


### PR DESCRIPTION
* Updated README.md to incorporate steps to build sln in Visual Studio. Included .gitignore and README.md file in the Solution under Solution items.

* Msvc (#37)

* to add MIT license in the repo

* formatting fix license.md

* Msvc (#38)

* to add MIT license in the repo

* formatting fix license.md

* changed copyright holder's name

* Msvc (#41)

* to add MIT license in the repo

* formatting fix license.md

* changed copyright holder's name